### PR TITLE
refactor: API Error 시 ApiError 인스턴스 반환

### DIFF
--- a/src/apis/common.ts
+++ b/src/apis/common.ts
@@ -10,10 +10,17 @@ const apiUrl = 'https://api.realworld.io/api';
  * API 호출 함수에서 발생하는 에러 타입
  * @param T info의 타입
  */
-export interface ApiError {
+export class ApiError extends Error {
   statusCode: number;
   errorMessage: string;
   info?: any;
+
+  constructor(statusCode: number, errorMessage: string, info?: any) {
+    super(errorMessage);
+    this.statusCode = statusCode;
+    this.errorMessage = errorMessage;
+    this.info = info;
+  }
 }
 
 /**
@@ -27,11 +34,7 @@ export interface ApiError {
  * @param getErrorMessage status code에 따라 에러 메시지를 결정하는 함수
  */
 function processError(error: any, errorMessages?: Record<number, string>): ApiError {
-  return {
-    statusCode: -1,
-    errorMessage: '문제가 발생했어요. 다시 시도하거나 문의해 주세요.',
-    info: error.response.data.errors,
-  };
+  return new ApiError(-1, '문제가 발생했어요. 다시 시도하거나 문의해 주세요.', error.response.data.errors);
 }
 
 /*


### PR DESCRIPTION
## 개요
현재 코드에서는 `ApiError` 라는 객체를 만들어서 반환하고 있는 것으로 보여요. 이 코드 대신에 `Error`클래스를 상속받은 커스텀 에러 클래스를 만들고, api에서 에러 발생시 커스텀 에러 인스턴스를 반환하는 건 어떤가요?

`Error` 을 상속받은 커스텀 에러 클래스를 사용하는 경우 다음과 같은 이점을 얻을 수 있어요.

1. `catch` 문에서 `if(error instanceof ApiError) {}` 로 `ApiError` 인지, 다른 에러인지 쉽게 구별할 수 있어요.
2. `error.stack`을 통해 에러가 발생한 스택을 추적할 수 있어요. (이외의 속성도 있어요.)
3. Error 클래스를 상속받지 않으면 예상하지 못하는 문제가 발생할 수 있어요.

사용자 정의 오류에 대해서 자세히 알아보시려면 아래 링크를 참고하시면 될 것 같아요

https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Error
https://stackoverflow.com/questions/1382107/whats-a-good-way-to-extend-error-in-javascript

## 변경사항
1. `src/apis/common.ts` 의 `processError` 함수와 `ApiError` 를 수정했어요.